### PR TITLE
Allow compilation on VS2010/net40, downgrading Ninject hint from net45-full to net40

### DIFF
--- a/Play.Tests/Play.Tests.csproj
+++ b/Play.Tests/Play.Tests.csproj
@@ -55,14 +55,14 @@
       <HintPath>..\packages\Newtonsoft.Json.4.5.1\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Ninject">
-      <HintPath>..\packages\Ninject.3.0.0.15\lib\net45-full\Ninject.dll</HintPath>
+      <HintPath>..\packages\Ninject.3.0.1.10\lib\net40\Ninject.dll</HintPath>
     </Reference>
     <Reference Include="Ninject.MockingKernel">
-      <HintPath>..\packages\Ninject.MockingKernel.3.0.0.5\lib\net45-full\Ninject.MockingKernel.dll</HintPath>
+      <HintPath>..\packages\Ninject.MockingKernel.3.0.0.5\lib\net40-full\Ninject.MockingKernel.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Ninject.MockingKernel.Moq">
-      <HintPath>..\packages\Ninject.MockingKernel.Moq.3.0.0.5\lib\net45-full\Ninject.MockingKernel.Moq.dll</HintPath>
+      <HintPath>..\packages\Ninject.MockingKernel.Moq.3.0.0.5\lib\net40-full\Ninject.MockingKernel.Moq.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NLog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">

--- a/Play.Tests/packages.config
+++ b/Play.Tests/packages.config
@@ -3,7 +3,7 @@
   <package id="FluentAssertions" version="1.7.1.1" />
   <package id="Microsoft.CompilerServices.AsyncTargetingPack" version="1.0.0" />
   <package id="Moq" version="4.0.10827" />
-  <package id="Ninject" version="3.0.0.15" />
+  <package id="Ninject" version="3.0.1.10" />
   <package id="Ninject.MockingKernel" version="3.0.0.5" />
   <package id="Ninject.MockingKernel.Moq" version="3.0.0.5" />
   <package id="NLog" version="2.0.0.2000" />

--- a/Play/Play.csproj
+++ b/Play/Play.csproj
@@ -96,7 +96,7 @@
       <HintPath>..\packages\Newtonsoft.Json.4.5.1\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Ninject">
-      <HintPath>..\packages\Ninject.3.0.0.15\lib\net40\Ninject.dll</HintPath>
+      <HintPath>..\packages\Ninject.3.0.1.10\lib\net40\Ninject.dll</HintPath>
     </Reference>
     <Reference Include="Ninject.Extensions.Logging">
       <HintPath>..\packages\Ninject.Extensions.Logging.3.0.0.7\lib\net40\Ninject.Extensions.Logging.dll</HintPath>

--- a/Play/Play.csproj
+++ b/Play/Play.csproj
@@ -96,13 +96,13 @@
       <HintPath>..\packages\Newtonsoft.Json.4.5.1\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Ninject">
-      <HintPath>..\packages\Ninject.3.0.0.15\lib\net45-full\Ninject.dll</HintPath>
+      <HintPath>..\packages\Ninject.3.0.0.15\lib\net40\Ninject.dll</HintPath>
     </Reference>
     <Reference Include="Ninject.Extensions.Logging">
-      <HintPath>..\packages\Ninject.Extensions.Logging.3.0.0.7\lib\net45-full\Ninject.Extensions.Logging.dll</HintPath>
+      <HintPath>..\packages\Ninject.Extensions.Logging.3.0.0.7\lib\net40\Ninject.Extensions.Logging.dll</HintPath>
     </Reference>
     <Reference Include="Ninject.Extensions.Logging.NLog2">
-      <HintPath>..\packages\Ninject.Extensions.Logging.nlog2.3.0.0.7\lib\net45-full\Ninject.Extensions.Logging.NLog2.dll</HintPath>
+      <HintPath>..\packages\Ninject.Extensions.Logging.nlog2.3.0.0.7\lib\net40\Ninject.Extensions.Logging.NLog2.dll</HintPath>
     </Reference>
     <Reference Include="NLog">
       <HintPath>..\packages\NLog.2.0.0.2000\lib\net40\NLog.dll</HintPath>

--- a/Play/packages.config
+++ b/Play/packages.config
@@ -4,7 +4,7 @@
   <package id="Ix_Experimental-Main" version="1.1.10823" />
   <package id="Microsoft.CompilerServices.AsyncTargetingPack" version="1.0.0" />
   <package id="Newtonsoft.Json" version="4.5.1" />
-  <package id="Ninject" version="3.0.0.15" />
+  <package id="Ninject" version="3.0.1.10" />
   <package id="Ninject.Extensions.Logging" version="3.0.0.7" />
   <package id="Ninject.Extensions.Logging.nlog2" version="3.0.0.7" />
   <package id="NLog" version="2.0.0.2000" />


### PR DESCRIPTION
This fix allows play-windows to compile and run on a VS2010/.NET4.0 installation that doesn't have any .NET4.5 assemblies installed (Windows XP!).
